### PR TITLE
Add Twitter reply functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1906,6 +1906,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2356,9 +2366,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.0.tgz",
-      "integrity": "sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==",
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,10 @@ export class TwitterServer {
                 type: 'string',
                 description: 'The content of your tweet',
                 maxLength: 280
+              },
+              reply_to_tweet_id: {
+                type: 'string',
+                description: 'Optional: ID of the tweet to reply to'
               }
             },
             required: ['text']
@@ -133,7 +137,7 @@ export class TwitterServer {
       );
     }
 
-    const tweet = await this.client.postTweet(result.data.text);
+    const tweet = await this.client.postTweet(result.data.text, result.data.reply_to_tweet_id);
     return {
       content: [{
         type: 'text',

--- a/src/twitter-api.ts
+++ b/src/twitter-api.ts
@@ -16,14 +16,19 @@ export class TwitterClient {
     console.error('Twitter API client initialized');
   }
 
-  async postTweet(text: string): Promise<PostedTweet> {
+  async postTweet(text: string, replyToTweetId?: string): Promise<PostedTweet> {
     try {
       const endpoint = 'tweets/create';
       await this.checkRateLimit(endpoint);
 
-      const response = await this.client.v2.tweet(text);
+      const tweetOptions: any = { text };
+      if (replyToTweetId) {
+        tweetOptions.reply = { in_reply_to_tweet_id: replyToTweetId };
+      }
+
+      const response = await this.client.v2.tweet(tweetOptions);
       
-      console.error(`Tweet posted successfully with ID: ${response.data.id}`);
+      console.error(`Tweet posted successfully with ID: ${response.data.id}${replyToTweetId ? ` (reply to ${replyToTweetId})` : ''}`);
       
       return {
         id: response.data.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,8 @@ export type Config = z.infer<typeof ConfigSchema>;
 export const PostTweetSchema = z.object({
     text: z.string()
         .min(1, 'Tweet text cannot be empty')
-        .max(280, 'Tweet cannot exceed 280 characters')
+        .max(280, 'Tweet cannot exceed 280 characters'),
+    reply_to_tweet_id: z.string().optional()
 });
 
 export const SearchTweetsSchema = z.object({


### PR DESCRIPTION
  Description:

  Summary

  This PR adds the ability to post tweets as replies to existing tweets, enabling users to create threaded conversations on
  Twitter through the MCP server.

  Changes

  - Added optional reply_to_tweet_id parameter to the post_tweet tool
  - Updated TwitterClient.postTweet() method to accept reply ID and construct appropriate tweet options
  - Modified schema and types to support the new reply parameter
  - Enhanced logging to indicate when a tweet is posted as a reply

  Implementation Details

  The reply functionality is implemented by:
  1. Adding an optional reply_to_tweet_id string parameter to the tool schema
  2. Passing this parameter to the Twitter API's reply option when provided
  3. Maintaining backward compatibility - existing code without the reply parameter continues to work as before

  Testing

  Tested locally by:
  - Posting regular tweets (without reply_to_tweet_id)
  - Posting reply tweets with valid tweet IDs
  - Verifying replies appear correctly in Twitter threads

  Backward Compatibility

  This change is fully backward compatible. The reply_to_tweet_id parameter is optional, so existing implementations will continue
   to function without modification.