### PR TITLE
feat: add post_tweet_with_image tool with image upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,30 @@ This MCP server allows Clients to interact with Twitter, enabling posting tweets
 
 3. Restart Claude Desktop
 
-That's it! Claude can now interact with Twitter through two tools:
+That's it! Claude can now interact with Twitter through three tools:
 
 - `post_tweet`: Post a new tweet
+- `post_tweet_with_image`: Post a tweet with an image (supports JPG, JPEG, PNG, GIF, WEBP)
 - `search_tweets`: Search for tweets
 
 ## Example Usage
 
 Try asking Claude:
 - "Can you post a tweet saying 'Hello from Claude!'"
+- "Post a tweet with the image at /path/to/image.png saying 'Check this out!'"
 - "Can you search for tweets about Claude AI?"
+
+### Posting a Tweet with an Image
+
+The `post_tweet_with_image` tool accepts:
+- `text` (required): The tweet content (max 280 characters)
+- `image_path` (required): Local file path to the image
+- `reply_to_tweet_id` (optional): Tweet ID to reply to
+
+Supported image formats: **JPG, JPEG, PNG, GIF, WEBP**
+
+
+**Important:** If you want to provide an image using a file path, the **File System MCP server** must be added to your MCP client, and the image must be in a folder that the server has access to. For example, if you have granted the Filesystem MCP Server access to your Desktop folder, you can say: *"Take the image myimage.png from my desktop and post it with the caption 'Hello world!'"*
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@enescinar/twitter-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@enescinar/twitter-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { TwitterClient } from './twitter-api.js';
 import { ResponseFormatter } from './formatter.js';
 import {
   Config, ConfigSchema,
-  PostTweetSchema, SearchTweetsSchema,
+  PostTweetSchema, PostTweetWithImageSchema, SearchTweetsSchema,
   TwitterError
 } from './types.js';
 import dotenv from 'dotenv';
@@ -83,6 +83,29 @@ export class TwitterServer {
           }
         } as Tool,
         {
+          name: 'post_tweet_with_image',
+          description: 'Post a tweet with an image to Twitter',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              text: {
+                type: 'string',
+                description: 'The content of your tweet',
+                maxLength: 280
+              },
+              image_path: {
+                type: 'string',
+                description: 'Local file path to the image (supports JPG, JPEG, PNG, GIF, WEBP)'
+              },
+              reply_to_tweet_id: {
+                type: 'string',
+                description: 'Optional: ID of the tweet to reply to'
+              }
+            },
+            required: ['text', 'image_path']
+          }
+        } as Tool,
+        {
           name: 'search_tweets',
           description: 'Search for tweets on Twitter',
           inputSchema: {
@@ -114,6 +137,8 @@ export class TwitterServer {
         switch (name) {
           case 'post_tweet':
             return await this.handlePostTweet(args);
+          case 'post_tweet_with_image':
+            return await this.handlePostTweetWithImage(args);
           case 'search_tweets':
             return await this.handleSearchTweets(args);
           default:
@@ -142,6 +167,28 @@ export class TwitterServer {
       content: [{
         type: 'text',
         text: `Tweet posted successfully!\nURL: https://twitter.com/status/${tweet.id}`
+      }] as TextContent[]
+    };
+  }
+
+  private async handlePostTweetWithImage(args: unknown) {
+    const result = PostTweetWithImageSchema.safeParse(args);
+    if (!result.success) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${result.error.message}`
+      );
+    }
+
+    const tweet = await this.client.postTweetWithImage(
+      result.data.text,
+      result.data.image_path,
+      result.data.reply_to_tweet_id
+    );
+    return {
+      content: [{
+        type: 'text',
+        text: `Tweet with image posted successfully!\nURL: https://twitter.com/status/${tweet.id}`
       }] as TextContent[]
     };
   }

--- a/src/twitter-api.ts
+++ b/src/twitter-api.ts
@@ -1,11 +1,16 @@
 import { TwitterApi } from 'twitter-api-v2';
 import { Config, TwitterError, Tweet, TwitterUser, PostedTweet } from './types.js';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export class TwitterClient {
   private client: TwitterApi;
   private rateLimitMap = new Map<string, number>();
 
+  private config: Config;
+
   constructor(config: Config) {
+    this.config = config;
     this.client = new TwitterApi({
       appKey: config.apiKey,
       appSecret: config.apiSecretKey,
@@ -37,6 +42,67 @@ export class TwitterClient {
     } catch (error) {
       this.handleApiError(error);
     }
+  }
+
+  async postTweetWithImage(text: string, imagePath: string, replyToTweetId?: string): Promise<PostedTweet> {
+    try {
+      const endpoint = 'tweets/create';
+      await this.checkRateLimit(endpoint);
+
+      if (!fs.existsSync(imagePath)) {
+        throw new TwitterError(
+          `Image file not found: ${imagePath}`,
+          'file_not_found',
+          404
+        );
+      }
+
+      const mediaId = await this.uploadMedia(imagePath);
+
+      const tweetOptions: any = { text };
+      tweetOptions.media = { media_ids: [mediaId] };
+      if (replyToTweetId) {
+        tweetOptions.reply = { in_reply_to_tweet_id: replyToTweetId };
+      }
+
+      const response = await this.client.v2.tweet(tweetOptions);
+
+      console.error(`Tweet with image posted successfully with ID: ${response.data.id}`);
+
+      return {
+        id: response.data.id,
+        text: response.data.text
+      };
+    } catch (error) {
+      this.handleApiError(error);
+    }
+  }
+
+  private async uploadMedia(filePath: string): Promise<string> {
+    const data = fs.readFileSync(filePath);
+    const mimeType = this.getMimeType(filePath);
+    const mediaId = await this.client.v1.uploadMedia(data, { mimeType });
+    return mediaId;
+  }
+
+  private getMimeType(filePath: string): string {
+    const ext = path.extname(filePath).toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.png': 'image/png',
+      '.gif': 'image/gif',
+      '.webp': 'image/webp'
+    };
+    const mimeType = mimeTypes[ext];
+    if (!mimeType) {
+      throw new TwitterError(
+        `Unsupported image format: ${ext}. Supported formats: JPG, JPEG, PNG, GIF, WEBP`,
+        'unsupported_format',
+        400
+      );
+    }
+    return mimeType;
   }
 
   async searchTweets(query: string, count: number): Promise<{ tweets: Tweet[], users: TwitterUser[] }> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,16 @@ export const SearchTweetsSchema = z.object({
 export type PostTweetArgs = z.infer<typeof PostTweetSchema>;
 export type SearchTweetsArgs = z.infer<typeof SearchTweetsSchema>;
 
+export const PostTweetWithImageSchema = z.object({
+    text: z.string()
+        .min(1, 'Tweet text cannot be empty')
+        .max(280, 'Tweet cannot exceed 280 characters'),
+    image_path: z.string().min(1, 'Image path is required'),
+    reply_to_tweet_id: z.string().optional()
+});
+
+export type PostTweetWithImageArgs = z.infer<typeof PostTweetWithImageSchema>;
+
 // API Response types
 export interface TweetMetrics {
     likes: number;


### PR DESCRIPTION
## Summary
Added a new `post_tweet_with_image` tool that allows posting tweets with attached images.
## Changes
- **src/types.ts** — Added `PostTweetWithImageSchema` and `PostTweetWithImageArgs` type
- **src/twitter-api.ts** — Added `postTweetWithImage()`, `uploadMedia()`, and `getMimeType()` methods
- **src/index.ts** — Registered the new tool in the MCP server with input schema and handler
- **README.md** — Added documentation and usage examples for the image posting feature
## Details
- Supports image formats: JPG, JPEG, PNG, GIF, WEBP
- Uses Twitter API v1.1 media upload endpoint via `twitter-api-v2`
- Image is read from local filesystem and uploaded, then attached to the tweet
- Follows existing code patterns (rate limiting, error handling, MCP response format)
## How to Test
Configure with your Twitter API credentials and run:
- "Post a tweet with the image at /path/to/image.png saying 'Hello!'"